### PR TITLE
prefer class on <html> rather than <body>

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module provides for all Origami hover effects to be turned on and off, and 
 
 ## Using in a product
 
-When you first add Origami CSS to a product, no hover effects will be triggered, and Origami components on your page will never react to hover.  To activate hover effects, add `o-hoverable-on` to the `<body>` tag:
+When you first add Origami CSS to a product, no hover effects will be triggered, and Origami components on your page will never react to hover.  To activate hover effects, add `o-hoverable-on` to the `<html>` tag:
 
 ```html
 <body class="o-hoverable-on">

--- a/main.js
+++ b/main.js
@@ -19,15 +19,19 @@ function Hoverable() {
 	var win = window;
 
 	function init() {
-		win.document.body.setAttribute('data-o-hoverable--js', '');
+		win.document.documentElement.setAttribute('data-o-hoverable--js', '');
 		touchSupport();
+	}
+
+	function updateClasses(action) {
+		document.body.classList[action](className); // deprecated
+		document.documentElement.classList[action](className);
 	}
 
 	// If body has hover effects enabled, and appears to support touch, remove hover effects and start listening for pointer interactions
 	function touchSupport() {
-		classList = win.document.body.classList;
 		if (classExists() && (('ontouchstart' in win) || (win.DocumentTouch && win.doc instanceof DocumentTouch))) {
-			classList.remove(className);
+			updateClasses('remove');
 			eventmap.forEach(function(item) {
 				listener('add', item[0], item[1]);
 			});
@@ -62,7 +66,7 @@ function Hoverable() {
 
 		// MSPointerHover categorically means a contactless interaction
 		if (contactlessMoves > 1 || event.type.toLowerCase() === 'mspointerhover') {
-			classList.add(className);
+			updateClasses('add');
 			eventmap.forEach(function(item) {
 				listener('remove', item[0], item[1]);
 			});
@@ -70,7 +74,7 @@ function Hoverable() {
 	}
 
 	function listener(type, event, fn) {
-		win[type+'EventListener'](event, fn, false);
+		win[type + 'EventListener'](event, fn, false);
 	}
 
 	function classExists() {
@@ -78,7 +82,7 @@ function Hoverable() {
 	}
 
 	function destroy() {
-		win.document.body.removeAttribute('data-o-hoverable--js');
+		win.document.documentElement.removeAttribute('data-o-hoverable--js');
 		eventmap.forEach(function(item) {
 			listener('remove', item[0], item[1]);
 		});
@@ -97,7 +101,7 @@ function Hoverable() {
 }
 
 Hoverable.init = function() {
-	if (!window.document.body.hasAttribute('data-o-hoverable--js')) {
+	if (!window.document.documentElement.hasAttribute('data-o-hoverable--js')) {
 		document.removeEventListener('o.DOMContentLoaded', Hoverable.init);
 		return new Hoverable();
 	}

--- a/main.js
+++ b/main.js
@@ -15,11 +15,9 @@ function Hoverable() {
 		['mspointerhover', contactMove]
 	];
 	var className = 'o-hoverable-on';
-	var classList;
-	var win = window;
 
 	function init() {
-		win.document.documentElement.setAttribute('data-o-hoverable--js', '');
+		document.documentElement.setAttribute('data-o-hoverable--js', '');
 		touchSupport();
 	}
 
@@ -30,7 +28,7 @@ function Hoverable() {
 
 	// If body has hover effects enabled, and appears to support touch, remove hover effects and start listening for pointer interactions
 	function touchSupport() {
-		if (classExists() && (('ontouchstart' in win) || (win.DocumentTouch && win.doc instanceof DocumentTouch))) {
+		if (classExists() && (('ontouchstart' in window) || (DocumentTouch && document instanceof DocumentTouch))) {
 			updateClasses('remove');
 			eventmap.forEach(function(item) {
 				listener('add', item[0], item[1]);
@@ -74,15 +72,15 @@ function Hoverable() {
 	}
 
 	function listener(type, event, fn) {
-		win[type + 'EventListener'](event, fn, false);
+		window[type + 'EventListener'](event, fn, false);
 	}
 
 	function classExists() {
-		return classList.contains(className);
+		return document.documentElement.classList.contains(className) || document.body.classList.contains(className);
 	}
 
 	function destroy() {
-		win.document.documentElement.removeAttribute('data-o-hoverable--js');
+		document.documentElement.removeAttribute('data-o-hoverable--js');
 		eventmap.forEach(function(item) {
 			listener('remove', item[0], item[1]);
 		});
@@ -101,7 +99,7 @@ function Hoverable() {
 }
 
 Hoverable.init = function() {
-	if (!window.document.documentElement.hasAttribute('data-o-hoverable--js')) {
+	if (!document.documentElement.hasAttribute('data-o-hoverable--js')) {
 		document.removeEventListener('o.DOMContentLoaded', Hoverable.init);
 		return new Hoverable();
 	}

--- a/test/hoverable.test.js
+++ b/test/hoverable.test.js
@@ -14,29 +14,29 @@ describe('o-hoverable', function() {
 	});
 
 	it('should initialise the module', function() {
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		testHoverable = new oHoverable();
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(true);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(true);
 	});
 
 	it('should destroy the module', function() {
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		testHoverable = new oHoverable();
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(true);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(true);
 		testHoverable.destroy();
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 	});
 
 	it('should initialise the module by emitting the o.DOMContentLoaded event', function() {
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(true);
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(true);
 	});
 
 	it('should check if class o-hoverable-on is set', function() {
 		testHoverable = new oHoverable();
 		expect(testHoverable.isHoverEnabled()).to.be(false);
-		document.body.classList.add('o-hoverable-on');
+		document.documentElement.classList.add('o-hoverable-on');
 		expect(testHoverable.isHoverEnabled()).to.be(true);
 	});
 
@@ -44,7 +44,8 @@ describe('o-hoverable', function() {
 		testHoverable = new oHoverable();
 		testHoverable.setClassName('hover-test');
 		expect(testHoverable.isHoverEnabled()).to.be(false);
-		document.body.classList.add('hover-test');
+		document.body.classList.add('hover-test'); // support deprecated class on body
+		document.documentElement.classList.add('hover-test');
 		expect(testHoverable.isHoverEnabled()).to.be(true);
 	});
 });


### PR DESCRIPTION
@AlbertoElias 

Aiming to make it backwards compatible (but only for things actually documented in the readme), so e.g. if people were relying on data-o-hoverable-js on body (undocumented) it'll break