### PR TITLE
Use HTML for class names as well as the body element

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"
 before_install:
-  - npm install -g https://github.com/Financial-Times/origami-build-tools/tarball/node-0.10
-  - origami-build-tools install
+  - npm install -g Financial-Times/origami-build-tools#node-0.10
+  - obt install
 script:
-  - origami-build-tools test
-  - origami-build-tools verify
+  - obt test
+  - obt verify

--- a/README.md
+++ b/README.md
@@ -1,28 +1,64 @@
 # Origami hover effects [![Build Status](https://travis-ci.org/Financial-Times/o-hoverable.png?branch=master)](https://travis-ci.org/Financial-Times/o-hoverable)
 
+Helper to activate hover states only on devices that support them, preventing unintended hover effects from happening on touch devices.
+
+## Quick start
+
+Add this class to the document to enable hover effects:
+
+```html
+<!-- This class gets removed on touch devices -->
+<html class="o-hoverable-on">
+```
+
+## Why o-hoverable?
+
 It's common for interactive elements on web pages to have hover effects, either via JavaScript `mouse*` events, or via CSS `:hover` pseudoclasses.  However, while some users will be interacting with your web page using a mouse, others may be using a touch screen.  Since touch screens typically don't have a 'hover' capability, hover effects are usually undesirable.
 
-In fact, some touch devices may have 'emulated hover', where the first touch activates a hover effect and the second is treated as a click.  This is a way for the browser to provide a way to use pages that 'require' hover (eg to select a flyout menu option) but this is also usually undesirable if you design your site sensibly.
+In fact, some touch devices may have 'emulated hover', where the first touch activates a hover effect and the second is treated as a click.  This is a way for the browser to provide a way to use pages that 'require' hover (e.g. to select a flyout menu option) but this is also usually undesirable if you design your site sensibly.
 
 This module provides for all Origami hover effects to be turned on and off, and provides a JavaScript utility to do so intelligently based on the input devices available to the user.
 
-## Using in a product
+## Advanced documentation
 
-When you first add Origami CSS to a product, no hover effects will be triggered, and Origami components on your page will never react to hover.  To activate hover effects, add `o-hoverable-on` to the `<body>` tag:
+### Styling
 
-```html
-<body class="o-hoverable-on">
+Component developers *must* prefix `:hover` states with `$o-hoverable-if-hover-enabled`, allowing hover effects to be configured by this module:
+
+```scss
+@import 'o-hoverable/main';
+
+#{$o-hoverable-if-hover-enabled} .o-mymodule-button:hover {
+	// Paint it black, if hover is enabled
+	background: black;
+}
 ```
 
-This will unconditionally add hover effects, so hover now acts as you would expect from a web page that has defined `:hover` pseudoclasses.
+Compiles to:
 
-To activate smart hover switching, add the class and also include this module's JavaScript in your bundle. You can then instantiate by running the `oHoverable#init()` function or by dispatching the `o.DOMContentLoaded` event.
+```scss
+.o-hoverable-on .o-mymodule-button:hover {
+	background: black;
+}
+```
 
-This will intelligently disable hovering on devices that support touch, and will re-enable it as soon as a non-touch hover event (ie, a mouse) is detected.
+### JavaScript
+
+Component developers *must* load hover effects conditionnally:
+
+```javascript
+function showMyMenuOnHover() {
+	if (!require('o-hoverable').isHoverEnabled()) {
+		// Hover isn't supported: don't do anything
+		return;
+	}
+	// Hover is supported: show a menu
+}
+```
 
 ### Configuring the class
 
-If you want to change the class used to trigger hover effects, you can do so by redefining the `$o-hoverable-if-hover-enabled` variable before importing this module's SASS.
+If you want to change the class used to trigger hover effects, you can do so by redefining the `$o-hoverable-if-hover-enabled` variable before importing this module's Sass.
 
 ```scss
 $o-hoverable-if-hover-enabled: '.do-that-hover-thang';
@@ -31,20 +67,26 @@ $o-hoverable-if-hover-enabled: '.do-that-hover-thang';
 And calling `setClassName` on the JavaScript module:
 
 ```javascript
-require('o-hoverable').setClassName('do-that-hover-thang')
+require('o-hoverable').setClassName('do-that-hover-thang');
 ```
-Make sure you do both of these, so that any JavaScript that
 
-## Using in components
+## Disabling o-hoverable
 
-Component developers *must* prefix any `:hover` pseudoclass with the `$o-hoverable-if-hover-enabled` variable, to allow your hover effect to be controlled by this module:
+Restore hover effects on all devices (even touch devices):
 
 ```scss
-#{$o-hoverable-if-hover-enabled} .o-mymodule-button:hover { background: red; };
+$o-hoverable-if-hover-enabled: '';
+@import 'o-hoverable/main';
+
+#{$o-hoverable-if-hover-enabled} .o-mymodule-button:hover {
+	// Paint it black is hover is supported
+	background: black;
+}
 ```
 
-In JavaScript, bind hover events as normal, but when they fire, check hover status, and don't take any action if hover is not enabled.
-
-```javascript
-if (!require('o-hoverable').isHoverEnabled()) return;
+Compiles to:
+```scss
+.o-mymodule-button:hover {
+	background: black;
+}
 ```

--- a/demos/demo.html
+++ b/demos/demo.html
@@ -3,18 +3,19 @@
 <!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
-    <meta charset="utf-8" />
-    <title>o-hoverable: demo demo</title>
-    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    <script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-    <style>body { margin: 0; }.demo-js .o--if-nojs { display: none; }</style>
-    <link rel="stylesheet" href="/bundles/css?modules=o-hoverable:/demos/src/demo.scss" />
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+	<title>o-hoverable: demo demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:classlist,default"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-hoverable:/demos/src/demo.scss" />
 </head>
 <body class="o-hoverable-on">
-    <script>(function(d) {var b = d.getElementsByTagName('body')[0];b.className = b.className + ' demo-js';})(document);</script>
-    <div>Green when hoverable, red = not hoverable</div>
+<div>Green when hoverable, red = not hoverable</div>
 
-    <script src="/bundles/js?modules=o-hoverable:/demos/src/demo.js"></script>
-    <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+<script src="/bundles/js?modules=o-hoverable:/demos/src/demo.js"></script>
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -32,7 +32,7 @@ function Hoverable() {
 		htmlClassList = window.document.documentElement.classList;
 		bodyClassList = window.document.body.classList;
 
-		if (classExists() && (('ontouchstart' in window) || (DocumentTouch && doc instanceof DocumentTouch))) {
+		if (classExists() && (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch)) {
 			htmlClassList.remove(className);
 			bodyClassList.remove(className);
 

--- a/main.js
+++ b/main.js
@@ -3,7 +3,10 @@
 
 function Hoverable() {
 
-	var hasContact = false, contactlessMoves = 0, lastClientX, lastClientY;
+	var hasContact = false;
+	var contactlessMoves = 0;
+	var lastClientX;
+	var lastClientY;
 	var eventmap = [
 		['touchstart', contactStart],
 		['mousedown', contactStart],
@@ -15,19 +18,24 @@ function Hoverable() {
 		['mspointerhover', contactMove]
 	];
 	var className = 'o-hoverable-on';
-	var classList;
-	var win = window;
+	var htmlClassList;
+	var bodyClassList; // Legacy
 
 	function init() {
-		win.document.body.setAttribute('data-o-hoverable--js', '');
+		window.document.documentElement.setAttribute('data-o-hoverable--js', '');
+		window.document.body.setAttribute('data-o-hoverable--js', '');
 		touchSupport();
 	}
 
 	// If body has hover effects enabled, and appears to support touch, remove hover effects and start listening for pointer interactions
 	function touchSupport() {
-		classList = win.document.body.classList;
-		if (classExists() && (('ontouchstart' in win) || (win.DocumentTouch && win.doc instanceof DocumentTouch))) {
-			classList.remove(className);
+		htmlClassList = window.document.documentElement.classList;
+		bodyClassList = window.document.body.classList;
+
+		if (classExists() && (('ontouchstart' in window) || (DocumentTouch && doc instanceof DocumentTouch))) {
+			htmlClassList.remove(className);
+			bodyClassList.remove(className);
+
 			eventmap.forEach(function(item) {
 				listener('add', item[0], item[1]);
 			});
@@ -62,7 +70,9 @@ function Hoverable() {
 
 		// MSPointerHover categorically means a contactless interaction
 		if (contactlessMoves > 1 || event.type.toLowerCase() === 'mspointerhover') {
-			classList.add(className);
+			htmlClassList.add(className);
+			bodyClassList.add(className);
+
 			eventmap.forEach(function(item) {
 				listener('remove', item[0], item[1]);
 			});
@@ -70,15 +80,17 @@ function Hoverable() {
 	}
 
 	function listener(type, event, fn) {
-		win[type+'EventListener'](event, fn, false);
+		window[type + 'EventListener'](event, fn, false);
 	}
 
 	function classExists() {
-		return classList.contains(className);
+		return htmlClassList.contains(className) || bodyClassList.contains(className);
 	}
 
 	function destroy() {
-		win.document.body.removeAttribute('data-o-hoverable--js');
+		window.document.documentElement.removeAttribute('data-o-hoverable--js');
+		window.document.body.removeAttribute('data-o-hoverable--js');
+
 		eventmap.forEach(function(item) {
 			listener('remove', item[0], item[1]);
 		});
@@ -97,7 +109,7 @@ function Hoverable() {
 }
 
 Hoverable.init = function() {
-	if (!window.document.body.hasAttribute('data-o-hoverable--js')) {
+	if (!window.document.documentElement.hasAttribute('data-o-hoverable--js') || !window.document.body.hasAttribute('data-o-hoverable--js')) {
 		document.removeEventListener('o.DOMContentLoaded', Hoverable.init);
 		return new Hoverable();
 	}

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,9 @@
+////
+/// @group o-hoverable
+/// @link http://registry.origami.ft.com/components/o-hoverable
+////
+
+
 /// Class used to trigger hover effects
 ///
 /// @type {String}

--- a/test/hoverable.test.js
+++ b/test/hoverable.test.js
@@ -14,37 +14,59 @@ describe('o-hoverable', function() {
 	});
 
 	it('should initialise the module', function() {
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
 		testHoverable = new oHoverable();
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(true);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(true);
 	});
 
 	it('should destroy the module', function() {
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
 		testHoverable = new oHoverable();
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(true);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(true);
 		testHoverable.destroy();
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
 	});
 
 	it('should initialise the module by emitting the o.DOMContentLoaded event', function() {
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(false);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(false);
 		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+		expect(window.document.documentElement.hasAttribute('data-o-hoverable--js')).to.be(true);
 		expect(window.document.body.hasAttribute('data-o-hoverable--js')).to.be(true);
 	});
 
-	it('should check if class o-hoverable-on is set', function() {
+	it('should check if class o-hoverable-on is set on <html>', function() {
 		testHoverable = new oHoverable();
 		expect(testHoverable.isHoverEnabled()).to.be(false);
-		document.body.classList.add('o-hoverable-on');
+		window.document.documentElement.classList.add('o-hoverable-on');
 		expect(testHoverable.isHoverEnabled()).to.be(true);
 	});
 
-	it('should set custom class', function() {
+	it('should check if class o-hoverable-on is set on <body>', function() {
+		testHoverable = new oHoverable();
+		expect(testHoverable.isHoverEnabled()).to.be(false);
+		window.document.body.classList.add('o-hoverable-on');
+		expect(testHoverable.isHoverEnabled()).to.be(true);
+	});
+
+	it('should set custom class on <html>', function() {
 		testHoverable = new oHoverable();
 		testHoverable.setClassName('hover-test');
 		expect(testHoverable.isHoverEnabled()).to.be(false);
-		document.body.classList.add('hover-test');
+		window.document.documentElement.classList.add('hover-test');
+		expect(testHoverable.isHoverEnabled()).to.be(true);
+	});
+
+	it('should set custom class on <body>', function() {
+		testHoverable = new oHoverable();
+		testHoverable.setClassName('hover-test');
+		expect(testHoverable.isHoverEnabled()).to.be(false);
+		window.document.body.classList.add('hover-test');
 		expect(testHoverable.isHoverEnabled()).to.be(true);
 	});
 });


### PR DESCRIPTION
Supersedes #8 

- `window`: I've found that `window.document` (instead of `document`) might be needed for components in embedded iframes, but I don't know what type of test case we'd need for that
- Fixes the touch test, which lead to a parse error in IE9
- Adds tests for both body and html elements

Next major version to be released right after, removing classes on the body (then modules can be upgraded on a case-by-case basis after a quick test).