### PR TITLE
Deprecate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Origami hover effects [![Build Status](https://circleci.com/gh/Financial-Times/o-hoverable.png?style=shield&circle-token=b0af656f0c61d4711aaf95feff0fda15e76cf32e)](https://circleci.com/gh/Financial-Times/o-hoverable) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
+_Deprecated. We recommend the [hover](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover) or [any-hover](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover) media query instead._
+
 Helper to activate hover states only on devices that support them, preventing unintended hover effects from happening on touch devices.
 
 - [Usage](#usage)

--- a/origami.json
+++ b/origami.json
@@ -8,7 +8,7 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"
 	},
-	"supportStatus": "active",
+	"supportStatus": "deprecated",
 	"browserFeatures": {
 		"required": ["classlist"]
 	},


### PR DESCRIPTION
We recommend native "hover" or "any-hover" media queries.

https://github.com/Financial-Times/o-hoverable/issues/29